### PR TITLE
Answer 400 when a required form field is missing from a utility endpoint

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/UtilityApi.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/UtilityApi.kt
@@ -84,6 +84,14 @@ internal class UtilityApi(
         }.fold(
             transform = { documents -> ok().json().bodyValueAndAwait(documents) },
             recover = { error -> badRequest().json().bodyValueAndAwait(error) },
+            catch = { exception ->
+                if (exception is IllegalArgumentException) {
+                    log.warn("Could not validate MSO MDoc DeviceResponse.", exception)
+                    badRequest().buildAndAwait()
+                } else {
+                    throw exception
+                }
+            },
         )
 
     private suspend fun handleValidateSdJwtVc(request: ServerRequest): ServerResponse =
@@ -103,6 +111,14 @@ internal class UtilityApi(
                 ok().json().bodyValueAndAwait(reCreated)
             },
             recover = { error -> badRequest().json().bodyValueAndAwait(error.toJson()) },
+            catch = { exception ->
+                if (exception is IllegalArgumentException) {
+                    log.warn("Could not validate SD-JWT VC.", exception)
+                    badRequest().buildAndAwait()
+                } else {
+                    throw exception
+                }
+            },
         )
 
     private suspend fun handleProcessSdJwtVc(request: ServerRequest): ServerResponse =

--- a/src/main/resources/public/openapi.json
+++ b/src/main/resources/public/openapi.json
@@ -475,7 +475,7 @@
             }
           },
           "400": {
-            "description": "Bad request",
+            "description": "Bad request. A request that cannot be read, for example one missing the required `device_response` field, is answered without a body.",
             "content": {
               "application/json": {
                 "schema": {
@@ -549,7 +549,7 @@
             }
           },
           "400": {
-            "description": "Bad request",
+            "description": "Bad request. A request that cannot be read, for example one missing the required `sd_jwt_vc` or `nonce` field, is answered without a body.",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/UtilityApiTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/adapter/input/web/UtilityApiTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.verifier.endpoint.adapter.input.web
+
+import eu.europa.ec.eudi.verifier.endpoint.VerifierApplicationTest
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.reactive.function.BodyInserters
+import kotlin.test.Test
+
+/**
+ * A required form field that is not supplied is a client error on every utility endpoint.
+ */
+@VerifierApplicationTest
+internal class UtilityApiTest {
+    @Autowired
+    private lateinit var client: WebTestClient
+
+    private fun postFormExpectingBadRequest(
+        path: String,
+        vararg fields: Pair<String, String>,
+    ) {
+        val form = LinkedMultiValueMap<String, String>()
+        fields.forEach { (name, value) -> form.add(name, value) }
+        client
+            .post()
+            .uri(path)
+            .contentType(APPLICATION_FORM_URLENCODED)
+            .body(BodyInserters.fromFormData(form))
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+
+    @Test
+    fun `when nonce is not included in sd-jwt-vc validation, validation fails`() {
+        postFormExpectingBadRequest(UtilityApi.VALIDATE_SD_JWT_VC_PATH, "sd_jwt_vc" to SD_JWT_VC)
+    }
+
+    @Test
+    fun `when sd-jwt-vc is not included in sd-jwt-vc validation, validation fails`() {
+        postFormExpectingBadRequest(UtilityApi.VALIDATE_SD_JWT_VC_PATH, "nonce" to "nonce")
+    }
+
+    @Test
+    fun `when device response is not included in mso mdoc validation, validation fails`() {
+        postFormExpectingBadRequest(UtilityApi.VALIDATE_MSO_MDOC_DEVICE_RESPONSE_PATH)
+    }
+
+    @Test
+    fun `when sd-jwt-vc is not included in sd-jwt-vc processing, processing fails`() {
+        postFormExpectingBadRequest(UtilityApi.PROCESS_SD_JWT_VC_PATH)
+    }
+
+    companion object {
+        private const val SD_JWT_VC = "eyJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIn0.signature~"
+    }
+}


### PR DESCRIPTION
## Description

`handleValidateSdJwtVc` and `handleValidateMsoMdocDeviceResponse` pass only `transform` and `recover` to `fold`. `recover` intercepts raised values, not thrown ones, so the `IllegalArgumentException` that `requireNotNull` throws for an absent form field escapes to Spring and the client gets a 500. `application.properties` sets `spring.web.error.include-stacktrace=always`, so that 500 carries a stack trace.

`WalletApi.handleWalletResponse` and `VerifierApi.handleInitTransaction` already pass a third argument, `catch`, to the same `fold`, converting the one exception they expect and rethrowing everything else.

Against `main` at 89c030e, run with the `develop` profile:

```
$ curl -s -o /dev/null -w '%{http_code}\n' -X POST localhost:8080/utilities/validations/sdJwtVc \
    -H 'Content-type: application/x-www-form-urlencoded' --data-urlencode 'sd_jwt_vc=<a token>'
500

$ curl -s -o /dev/null -w '%{http_code}\n' -X POST localhost:8080/utilities/validations/msoMdoc/deviceResponse \
    -H 'Content-type: application/x-www-form-urlencoded' --data-urlencode 'foo=bar'
500
```

The 500 body carries the guard's own message: `"trace":"java.lang.IllegalArgumentException: device_response must be provided ...`.

## Changes

Adds `catch` to the two `fold` calls, converting `IllegalArgumentException` to a 400 and rethrowing anything else, the way `WalletApi` and `VerifierApi` do. A malformed request therefore answers with an empty 400, as it already does in those two files; the validation failures that `openapi.json` documents keep returning their JSON bodies through `recover`.

## Testing

`UtilityApiTest` covers all three handlers in the file. Without the change 3 of its 4 cases fail with `Status expected:<400 BAD_REQUEST> but was:<500 INTERNAL_SERVER_ERROR>`; the fourth exercises `handleProcessSdJwtVc`, which already had the guard, and passes before and after. `./gradlew build` reports 49 tests, 0 failures, spotless included.

Verified on macOS with Temurin 25, on top of `main` at 89c030e.
