### PR TITLE
Report every SD-JWT VC validation outcome on the wire

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/ValidateSdJwtVc.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/ValidateSdJwtVc.kt
@@ -51,7 +51,10 @@ internal enum class SdJwtVcValidationErrorCodeTO {
     IssuerCertificateIsNotTrusted,
     UnableToLookupDID,
     UnableToDetermineVerificationMethod,
+    TypeMetadataValidationFailure,
+    TypeMetadataResolutionFailure,
     StatusCheckFailed,
+    StatusNotValid,
     UnexpectedError,
     InvalidIssuerChain,
 }
@@ -144,4 +147,27 @@ private fun SdJwtVcValidationError.toSdJwtVcValidationError(): SdJwtVcValidation
     )
 
 private fun SdJwtVcValidationErrorCode.toSdJwtVcValidationErrorCodeTO(): SdJwtVcValidationErrorCodeTO =
-    SdJwtVcValidationErrorCodeTO.valueOf(name)
+    when (this) {
+        SdJwtVcValidationErrorCode.IsUnparsable -> SdJwtVcValidationErrorCodeTO.IsUnparsable
+        SdJwtVcValidationErrorCode.ContainsInvalidJwt -> SdJwtVcValidationErrorCodeTO.ContainsInvalidJwt
+        SdJwtVcValidationErrorCode.IsMissingHolderPublicKey -> SdJwtVcValidationErrorCodeTO.IsMissingHolderPublicKey
+        SdJwtVcValidationErrorCode.UnsupportedHolderPublicKey -> SdJwtVcValidationErrorCodeTO.UnsupportedHolderPublicKey
+        SdJwtVcValidationErrorCode.ContainsInvalidKeyBindingJwt -> SdJwtVcValidationErrorCodeTO.ContainsInvalidKeyBindingJwt
+        SdJwtVcValidationErrorCode.ContainsKeyBindingJwt -> SdJwtVcValidationErrorCodeTO.ContainsKeyBindingJwt
+        SdJwtVcValidationErrorCode.IsMissingKeyBindingJwt -> SdJwtVcValidationErrorCodeTO.IsMissingKeyBindingJwt
+        SdJwtVcValidationErrorCode.ContainsInvalidDisclosures -> SdJwtVcValidationErrorCodeTO.ContainsInvalidDisclosures
+        SdJwtVcValidationErrorCode.ContainsUnsupportedHashingAlgorithm -> SdJwtVcValidationErrorCodeTO.ContainsUnsupportedHashingAlgorithm
+        SdJwtVcValidationErrorCode.ContainsNonUniqueDigests -> SdJwtVcValidationErrorCodeTO.ContainsNonUniqueDigests
+        SdJwtVcValidationErrorCode.ContainsNonUniqueDisclosures -> SdJwtVcValidationErrorCodeTO.ContainsNonUniqueDisclosures
+        SdJwtVcValidationErrorCode.ContainsDisclosuresWithNoDigests -> SdJwtVcValidationErrorCodeTO.ContainsDisclosuresWithNoDigests
+        SdJwtVcValidationErrorCode.UnsupportedVerificationMethod -> SdJwtVcValidationErrorCodeTO.UnsupportedVerificationMethod
+        SdJwtVcValidationErrorCode.UnableToResolveIssuerMetadata -> SdJwtVcValidationErrorCodeTO.UnableToResolveIssuerMetadata
+        SdJwtVcValidationErrorCode.IssuerCertificateIsNotTrusted -> SdJwtVcValidationErrorCodeTO.IssuerCertificateIsNotTrusted
+        SdJwtVcValidationErrorCode.UnableToLookupDID -> SdJwtVcValidationErrorCodeTO.UnableToLookupDID
+        SdJwtVcValidationErrorCode.UnableToDetermineVerificationMethod -> SdJwtVcValidationErrorCodeTO.UnableToDetermineVerificationMethod
+        SdJwtVcValidationErrorCode.TypeMetadataValidationFailure -> SdJwtVcValidationErrorCodeTO.TypeMetadataValidationFailure
+        SdJwtVcValidationErrorCode.TypeMetadataResolutionFailure -> SdJwtVcValidationErrorCodeTO.TypeMetadataResolutionFailure
+        SdJwtVcValidationErrorCode.StatusCheckFailed -> SdJwtVcValidationErrorCodeTO.StatusCheckFailed
+        SdJwtVcValidationErrorCode.StatusNotValid -> SdJwtVcValidationErrorCodeTO.StatusNotValid
+        SdJwtVcValidationErrorCode.UnexpectedError -> SdJwtVcValidationErrorCodeTO.UnexpectedError
+    }

--- a/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/SdJwtVcValidationErrorCodeTOTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/verifier/endpoint/port/input/SdJwtVcValidationErrorCodeTOTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023-2026 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.europa.ec.eudi.verifier.endpoint.port.input
+
+import eu.europa.ec.eudi.verifier.endpoint.adapter.out.sdjwtvc.SdJwtVcValidationErrorCode
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+internal class SdJwtVcValidationErrorCodeTOTest {
+    /**
+     * Every validation outcome must be expressible on the wire, otherwise
+     * /utilities/validations/sdJwtVc cannot report it.
+     */
+    @Test
+    fun `every validation error code has a counterpart in the wire enum`() {
+        val wire = SdJwtVcValidationErrorCodeTO.entries.map { it.name }.toSet()
+        val missing = SdJwtVcValidationErrorCode.entries.map { it.name }.filterNot { it in wire }
+        assertTrue(missing.isEmpty(), "SdJwtVcValidationErrorCodeTO is missing $missing")
+    }
+}


### PR DESCRIPTION
## Description

Three of the outcomes `SdJwtVcValidationErrorCode` can produce — `StatusNotValid`, `TypeMetadataResolutionFailure` and `TypeMetadataValidationFailure` — had no constant in `SdJwtVcValidationErrorCodeTO`, the enum `/utilities/validations/sdJwtVc` answers with. The mapping between the two is `SdJwtVcValidationErrorCodeTO.valueOf(name)`, so reaching one of them raises `IllegalArgumentException: No enum constant` while the response is being built, and the caller gets a 500 instead of the documented 400.

The served `openapi.json` already lists all three under `SdJwtVcValidationErrorCode`, so the endpoint documents outcomes it cannot express.

`StatusNotValid` is reachable on the shipped defaults: `application.properties` has `verifier.validation.sdJwtVc.statusCheck.enabled=true`, and `StatusListTokenValidator` raises it for a revoked or suspended credential. The two `TypeMetadata` codes need `verifier.validation.sdJwtVc.typeMetadata.policy` set to something other than the default `not-used`.

## Changes

Adds the three constants and maps with an exhaustive `when` instead of `valueOf(name)`, so a code without a wire counterpart fails the build rather than surfacing at runtime. `DocumentError.toDocumentErrorTO()` on the mdoc side maps the same way, though as a `sealed interface` it had no other option.

## Testing

`SdJwtVcValidationErrorCodeTOTest` asserts every `SdJwtVcValidationErrorCode` has a counterpart on the wire. On `main` it fails naming the three missing constants; with this change it passes. `./gradlew build` reports 46 tests, 0 failures, spotless included.

Verified on macOS with Temurin 25, on top of `main` at 89c030e.
